### PR TITLE
Improve API

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Curently, you can configure two settings:
 Base API URL : `GET http://YOUR_OCTOPRINT_SERVER/api/plugin/octolight?action=ACTION_NAME`
 
 _(if the action parameter not given, the action toggle will be used by default)_
-#### Action
+#### Actions
 - **toggle** (default action): Toggle light switch on/off. JSON return example: `{state: true}`
 - **getState**: Get current light switch state. JSON return example: `{state: true}`
 

--- a/README.md
+++ b/README.md
@@ -25,10 +25,14 @@ Curently, you can configure two settings:
 ## API
 Base API URL : `GET http://YOUR_OCTOPRINT_SERVER/api/plugin/octolight?action=ACTION_NAME`
 
+This API always returns updated light state in JSON: `{state: true}`
+
 _(if the action parameter not given, the action toggle will be used by default)_
 #### Actions
-- **toggle** (default action): Toggle light switch on/off. JSON return example: `{state: true}`
-- **getState**: Get current light switch state. JSON return example: `{state: true}`
+- **toggle** (default action): Toggle light switch on/off.
+- **turnOn**: Turn on light.
+- **turnOff**: Turn off light.
+- **getState**: Get current light switch state.
 
 ## TO DO
 - [x] Update interface if Light is turned on or off

--- a/README.md
+++ b/README.md
@@ -13,15 +13,23 @@ or manually using this URL:
 ![Settings panel](img/settings.png)
 
 Curently, you can configure two settings:
-- `Light PIN`: The pin on the Raspberry Pi that the button controls. 
+- `Light PIN`: The pin on the Raspberry Pi that the button controls.
 	- Default value: 13
 	- The pin number is saved in the **board layout naming** scheme (gray labels on the pinout image below).
-	- **!! IMPORTANT !!** The Raspberry Pi can only controll the **GPIO** pins (orange labels on the pinout image below)
+	- **!! IMPORTANT !!** The Raspberry Pi can only control the **GPIO** pins (orange labels on the pinout image below)
 	![Raspberry Pi GPIO](img/rpi_gpio.png)
 
 - `Inverted output`: If true, the output will be inverted
 	- Usage: if you have a light, that is turned off when voltage is applied to the pin (wired in negative logic), you should turn on this option, so the light isn't on when you reboot your Raspberry Pi.
-	
+
+## API
+Base API URL : `GET http://YOUR_OCTOPRINT_SERVER/api/plugin/octolight?action=ACTION_NAME`
+
+_(if the action parameter not given, the action toggle will be used by default)_
+#### Action
+- **toggle** (default action): Toggle light switch on/off. JSON return example: `{state: true}`
+- **getState**: Get current light switch state. JSON return example: `{state: true}`
+
 ## TO DO
 - [x] Update interface if Light is turned on or off
 

--- a/octoprint_octolight/__init__.py
+++ b/octoprint_octolight/__init__.py
@@ -76,26 +76,31 @@ class OctoLightPlugin(
 		self._plugin_manager.send_plugin_message(self._identifier, dict(isLightOn=self.light_state))
 
 	def on_api_get(self, request):
-		# Sets the GPIO every time, if user changed it in the settings.
-		GPIO.setup(int(self._settings.get(["light_pin"])), GPIO.OUT)
+		action = request.args.get('action', default="toggle", type=str)
 
+		if action == "toggle":
+			# Sets the GPIO every time, if user changed it in the settings.
+			GPIO.setup(int(self._settings.get(["light_pin"])), GPIO.OUT)
 
-		self.light_state = not self.light_state
+			self.light_state = not self.light_state
 
-		# Sets the light state depending on the inverted output setting (XOR)
-		if self.light_state ^ self._settings.get(["inverted_output"]):
-			GPIO.output(int(self._settings.get(["light_pin"])), GPIO.HIGH)
+			# Sets the light state depending on the inverted output setting (XOR)
+			if self.light_state ^ self._settings.get(["inverted_output"]):
+				GPIO.output(int(self._settings.get(["light_pin"])), GPIO.HIGH)
+			else:
+				GPIO.output(int(self._settings.get(["light_pin"])), GPIO.LOW)
+
+			self._logger.info("Got request. Light state: {}".format(
+				self.light_state
+			))
+
+			self._plugin_manager.send_plugin_message(self._identifier, dict(isLightOn=self.light_state))
+
+			return flask.jsonify(state=self.light_state)
+		elif action == "getState":
+			return flask.jsonify(state=self.light_state)
 		else:
-			GPIO.output(int(self._settings.get(["light_pin"])), GPIO.LOW)
-
-		self._logger.info("Got request. Light state: {}".format(
-			self.light_state
-		))
-
-		self._plugin_manager.send_plugin_message(self._identifier, dict(isLightOn=self.light_state))
-
-
-		return flask.jsonify(status="ok")
+			return flask.jsonify(error="action not recognized")
 
 	def on_event(self, event, payload):
 		if event == Events.CLIENT_OPENED:

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_octolight"
 plugin_name = "OctoLight"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.1.2"
+plugin_version = "0.1.3"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
Hello,

I propose some changes regarding the OctoLight API.
- Now, we are able to retrieve the current state of the light.
- When toggle action is sent, return the current state (`"{state: true}"` or `"{state: false}"`) instead of `"{status: ok}"`
- Add an API section in README

In order to do that i added an "action" GET parameter to the base API endpoint:

`GET http://YOUR_OCTOPRINT_SERVER/api/plugin/octolight?action=ACTION_NAME`
_(default action name is toggle)_

This action parameter has the "toggle" default value which allows you to toggle switch like before : `GET http://YOUR_OCTOPRINT_SERVER/api/plugin/octolight` OR  `GET http://YOUR_OCTOPRINT_SERVER/api/plugin/octolight?action=toggle`

A second value is also available: getState which retrieves the current light state by using this endpoint:  `GET http://YOUR_OCTOPRINT_SERVER/api/plugin/octolight?action=getState`

I think this improvement can give more freedom in automation.

Thank you for your attention.
