### PR TITLE
Make OctoLight work with RPi's GPIO in BOARD or BCM numbering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # OctoLight
-A simple plugin that adds a button to the navigation bar for toggleing a GPIO pin on the Raspberry Pi.
+A simple plugin that adds a button to the navigation bar for toggling a GPIO pin on the Raspberry Pi.
 
 ![WebUI interface](img/screenshoot.png)
 
@@ -12,15 +12,17 @@ or manually using this URL:
 ## Configuration
 ![Settings panel](img/settings.png)
 
-Curently, you can configure two settings:
+Currently, you can configure three settings:
 - `Light PIN`: The pin on the Raspberry Pi that the button controls.
 	- Default value: 13
 	- The pin number is saved in the **board layout naming** scheme (gray labels on the pinout image below).
 	- **!! IMPORTANT !!** The Raspberry Pi can only control the **GPIO** pins (orange labels on the pinout image below)
 	![Raspberry Pi GPIO](img/rpi_gpio.png)
 
-- `Inverted output`: If true, the output will be inverted
+- `Inverted output`: If true, the output will be inverted.
 	- Usage: if you have a light, that is turned off when voltage is applied to the pin (wired in negative logic), you should turn on this option, so the light isn't on when you reboot your Raspberry Pi.
+
+- `Turn on at startup`: If true, the light will be turned on when OctoPrint (re)starts.
 
 ## API
 Base API URL : `GET http://YOUR_OCTOPRINT_SERVER/api/plugin/octolight?action=ACTION_NAME`

--- a/octoprint_octolight/__init__.py
+++ b/octoprint_octolight/__init__.py
@@ -33,10 +33,27 @@ class OctoLightPlugin(
 			return bcm_map[board_pin - 1]
 		return -1
 
+	def set_light_on(self, turn_on):
+		self.light_state = turn_on
+		pin = self.get_light_pin()
+		# Sets the GPIO every time, if user changed it in the settings.
+		GPIO.setup(pin, GPIO.OUT)
+		# Sets the light state depending on the inverted output setting (XOR)
+		if bool(self._settings.get(["inverted_output"])):
+			GPIO.output(pin, GPIO.LOW if turn_on else GPIO.HIGH)
+		else:
+			GPIO.output(pin, GPIO.HIGH if turn_on else GPIO.LOW)
+		self._logger.info("Light is {} on channel {}".format(
+			"ON" if turn_on else "OFF",
+			pin
+		))
+		self._plugin_manager.send_plugin_message(self._identifier, dict(isLightOn=self.light_state))
+
 	def get_settings_defaults(self):
 		return dict(
 			light_pin = 13,
-			inverted_output = False
+			inverted_output = False,
+			start_on = False,
 		)
 
 	def get_template_configs(self):
@@ -65,60 +82,24 @@ class OctoLightPlugin(
 			self.gpio_board_mode = False
 		GPIO.setwarnings(False)
 
-		self.light_state = False
 		self._logger.info("--------------------------------------------")
 		self._logger.info("OctoLight started, listening for GET request")
-		self._logger.info("Light pin: {}, inverted_input: {}".format(
+		self._logger.info("Light pin: {}, inverted_input: {}, start_on: {}".format(
 			self._settings.get(["light_pin"]),
-			self._settings.get(["inverted_output"])
+			self._settings.get(["inverted_output"]),
+			self._settings.get(["start_on"])
 		))
 		self._logger.info("--------------------------------------------")
 
-		# Setting the default state of pin
-		pin = self.get_light_pin()
-		GPIO.setup(pin, GPIO.OUT)
-		if bool(self._settings.get(["inverted_output"])):
-			GPIO.output(pin, GPIO.HIGH)
-		else:
-			GPIO.output(pin, GPIO.LOW)
-
-		#Because light is set to ff on startup we don't need to retrieve the current state
-		"""
-		r = self.light_state = GPIO.input(pin)
-        if r==1:
-                self.light_state = False
-        else:
-                self.light_state = True
-
-        self._logger.info("After Startup. Light state: {}".format(
-                self.light_state
-        ))
-        """
-
-		self._plugin_manager.send_plugin_message(self._identifier, dict(isLightOn=self.light_state))
+		# Set the initial state of the light
+		self.set_light_on(self._settings.get(["start_on"]))
 
 	def light_toggle(self):
-		# Sets the GPIO every time, if user changed it in the settings.
-		pin = self.get_light_pin()
-		GPIO.setup(pin, GPIO.OUT)
-
-		self.light_state = not self.light_state
-
-		# Sets the light state depending on the inverted output setting (XOR)
-		if self.light_state ^ self._settings.get(["inverted_output"]):
-			GPIO.output(pin, GPIO.HIGH)
-		else:
-			GPIO.output(pin, GPIO.LOW)
-
-		self._logger.info("Got request. Light state on channel {}: {}".format(
-			pin,
-			self.light_state
-		))
-
-		self._plugin_manager.send_plugin_message(self._identifier, dict(isLightOn=self.light_state))
+		self.set_light_on(not self.light_state)
 
 	def on_api_get(self, request):
 		action = request.args.get('action', default="toggle", type=str)
+		self._logger.info("Got API request '{}'".format(action))
 
 		if action == "toggle":
 			self.light_toggle()

--- a/octoprint_octolight/templates/octolight_settings.jinja2
+++ b/octoprint_octolight/templates/octolight_settings.jinja2
@@ -11,6 +11,14 @@
 				<input type="checkbox" data-bind="checked: settings.plugins.octolight.inverted_output">
 				{{ _('Inverted output') }}
 			</label>
+			<div class="help-block">{{ _('For further information on which pin numbers are valid, see the <a target="_blank" href="https://github.com/gigibu5/OctoLight#configuration">plugin documentation</a>.') }}</div>
+		</div>
+	</div>
+
+	<div class="control-group">
+		<label class="control-label">{{ _('Turn on at startup') }}</label>
+		<div class="controls">
+			<input class="input-checkbox" type="checkbox" data-bind="checked: settings.plugins.octolight.start_on">
 		</div>
 	</div>
 </form>


### PR DESCRIPTION
Instead of initializing GPIO in BOARD mode, only do it if it's not already
setup, otherwise use the already setup mode. Translate pin numbering on-the-fly,
thus no UI changes are necessary.

This way, OctoLight works nicely with other plugins that use RPi's GPIO,
like OctoPrint Micro Panel.

Tested with OctoPrint 1.7.2 + Python 3.7.3 + OctoPi 0.18.0 + OctoPrint
Micro Panel 3.0.1 (all latest versions).

Fixes #29 